### PR TITLE
fix the FQDN no chart shown issue by modify key words

### DIFF
--- a/default/app.conf
+++ b/default/app.conf
@@ -9,7 +9,7 @@ label = Splunk App for Aviatrix
 [launcher]
 author = rakesh@aviatrix.com
 description = Aviatrix App for Splunk is an advanced reporting and analysis tool for Aviatrix hybrid cloud networking solution.
-version = 1.3
+version = 1.5
 
 [package]
 id = SplunkforAviatrix

--- a/default/data/ui/views/security_overview.xml
+++ b/default/data/ui/views/security_overview.xml
@@ -18,7 +18,7 @@
       <fieldForLabel>Gateway</fieldForLabel>
       <fieldForValue>Gateway</fieldForValue>
       <search>
-        <query>`aviatrix_log` AviatrixFQDNRule | chart count by Gateway</query>
+        <query>`aviatrix_log` AviatrixFQDNRule* | chart count by Gateway</query>
         <earliest>$earliest$</earliest>
         <latest>$latest$</latest>
       </search>
@@ -65,7 +65,7 @@
         <option name="trellis.scales.shared">1</option>
         <option name="trellis.size">medium</option>
         <drilldown>
-          <link target="_blank">search?q=`aviatrix_log` AviatrixFQDNRule* "state=MATCHED" | search Gateway=$gw_name$ | chart count by hostname&amp;earliest=$earliest$&amp;latest=$latest$</link>
+          <link target="_blank">search?q=`aviatrix_log` AviatrixFQDNRule* NOT "drop_reason" | search Gateway=$gw_name$ | chart count by hostname&amp;earliest=$earliest$&amp;latest=$latest$</link>
         </drilldown>
       </chart>
     </panel>
@@ -107,7 +107,7 @@
         <option name="trellis.scales.shared">1</option>
         <option name="trellis.size">medium</option>
         <drilldown>
-          <link target="_blank">search?q=`aviatrix_log` AviatrixFQDNRule* "state=NO_MATCH"  | search Gateway=$gw_name$ | chart count by hostname&amp;earliest=$earliest$&amp;latest=$latest$</link>
+          <link target="_blank">search?q=`aviatrix_log` AviatrixFQDNRule* "drop_reason"  | search Gateway=$gw_name$ | chart count by hostname&amp;earliest=$earliest$&amp;latest=$latest$</link>
         </drilldown>
       </chart>
     </panel>

--- a/default/data/ui/views/security_overview.xml
+++ b/default/data/ui/views/security_overview.xml
@@ -31,7 +31,7 @@
       <title>FQDN Accepted Domain Names</title>
       <chart>
         <search>
-          <query>`aviatrix_log` AviatrixFQDNRule process_http() Gateway=$gw_name$ NOT "drop_reason"| chart count as Num_connections by hostname</query>
+          <query>`aviatrix_log` AviatrixFQDNRule* Gateway=$gw_name$ NOT "drop_reason"| chart count as Num_connections by hostname</query>
           <earliest>$earliest$</earliest>
           <latest>$latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -65,7 +65,7 @@
         <option name="trellis.scales.shared">1</option>
         <option name="trellis.size">medium</option>
         <drilldown>
-          <link target="_blank">search?q=`aviatrix_log` AviatrixFQDNRule process_http() "state=MATCHED" | search Gateway=$gw_name$ | chart count by hostname&amp;earliest=$earliest$&amp;latest=$latest$</link>
+          <link target="_blank">search?q=`aviatrix_log` AviatrixFQDNRule* "state=MATCHED" | search Gateway=$gw_name$ | chart count by hostname&amp;earliest=$earliest$&amp;latest=$latest$</link>
         </drilldown>
       </chart>
     </panel>
@@ -73,7 +73,7 @@
       <title>FQDN Blocked Domain Names</title>
       <chart>
         <search>
-          <query>`aviatrix_log` AviatrixFQDNRule process_http() "drop_reason" Gateway=$gw_name$ | chart count as Num_connections by hostname</query>
+          <query>`aviatrix_log` AviatrixFQDNRule* "drop_reason" Gateway=$gw_name$ | chart count as Num_connections by hostname</query>
           <earliest>$earliest$</earliest>
           <latest>$latest$</latest>
           <sampleRatio>1</sampleRatio>
@@ -107,7 +107,7 @@
         <option name="trellis.scales.shared">1</option>
         <option name="trellis.size">medium</option>
         <drilldown>
-          <link target="_blank">search?q=`aviatrix_log` AviatrixFQDNRule "state=NO_MATCH"  | search Gateway=$gw_name$ | chart count by hostname&amp;earliest=$earliest$&amp;latest=$latest$</link>
+          <link target="_blank">search?q=`aviatrix_log` AviatrixFQDNRule* "state=NO_MATCH"  | search Gateway=$gw_name$ | chart count by hostname&amp;earliest=$earliest$&amp;latest=$latest$</link>
         </drilldown>
       </chart>
     </panel>


### PR DESCRIPTION
Discussed with James and Ramki, 2 changes made:
1. Changing 'AviatrixFQDNRule' to 'AviatrixFQDNRule*' which for now both the AviatrixFQDNRule and AviatrixFQDNRule0,1,2,3 will be accepted.
2. Removed the 'process_http()' because we should show the log/chart for both http and https. 